### PR TITLE
fix the problem with the wget warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,13 +51,12 @@ class phpunit(
         timeout     => $timeout,
         verbose     => false,
         require     => Package[$package],
-      }
+      }->
 
       file { 'phpunit-phar':
         ensure  => $ensure,
         mode    => 'a+x',
         path    => $install_path,
-        require => wget::fetch['phpunit-phar-wget'],
       }
     }
     /(absent)/: {


### PR DESCRIPTION
Wget creates a warning about converting string to no boolean value if you do the require in the current format. The arrow require does not throw this error.
